### PR TITLE
Pipeline v0.2.0: Update micall lite galaxy tool to use micall-lite v0.1rc3

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In order to use this pipeline, you will also have to install several Galaxy tool
 
 | Name                               | Version         | Owner                          | Metadata Revision | Galaxy Toolshed Link                                                                                                                                                    |
 |------------------------------------|-----------------|--------------------------------|-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| suite_micall_lite                  |                 | `public-health-bioinformatics` | 0 (2020-01-06)    | [suite_micall_lite-0:a33882bffea1](https://toolshed.g2.bx.psu.edu/view/public-health-bioinformatics/suite_micall_lite/a33882bffea1)                                                                              |
+| suite_micall_lite                  |                 | `public-health-bioinformatics` | 2 (2020-01-08)    | [suite_micall_lite-2:e9618b79c799](https://toolshed.g2.bx.psu.edu/view/public-health-bioinformatics/suite_micall_lite/e9618b79c799)                                     |
 
 
 # Building/Packaging

--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,14 @@
 
 	<groupId>org.publichealthbioinformatics</groupId>
 	<artifactId>irida-plugin-micall-lite</artifactId>
-	<version>0.1.1</version>
+	<version>0.2.0</version>
 
 	<!-- Please fill out these properties with information about your particular plugin -->
 	<properties>
 		<!-- Information used to define properties about a plugin. Please see the PF4J docs for more details https://pf4j.org/doc/getting-started.html -->
 		<plugin.id>micall-lite</plugin.id>
 		<plugin.class>org.publichealthbioinformatics.irida.plugin.micalllite.MicallLitePlugin</plugin.class>
-		<plugin.version>0.1.1</plugin.version>
+		<plugin.version>0.2.0</plugin.version>
 		<plugin.provider>Dan Fornika</plugin.provider>
 		<plugin.dependencies></plugin.dependencies>
 		<plugin.requires.runtime>1.0.0</plugin.requires.runtime>

--- a/src/main/java/org/publichealthbioinformatics/irida/plugin/micalllite/MicallLitePlugin.java
+++ b/src/main/java/org/publichealthbioinformatics/irida/plugin/micalllite/MicallLitePlugin.java
@@ -70,14 +70,14 @@ public class MicallLitePlugin extends Plugin {
 		 * <strong>id</strong> entry in the <strong>irida_workflow.xml</strong> file.
 		 * 
 		 * <pre>
-		 * {@code <id>06acbde5-cfc2-4eb1-880c-4b2f85be1adc</id>}
+		 * {@code <id>d9820957-5ffc-4a25-b98b-c1a655ad39f7</id>}
 		 * </pre>
 		 * 
 		 * @return A {@link UUID} defining the id of this pipeline.
 		 */
 		@Override
 		public UUID getDefaultWorkflowUUID() {
-			return UUID.fromString("06acbde5-cfc2-4eb1-880c-4b2f85be1adc");
+			return UUID.fromString("d9820957-5ffc-4a25-b98b-c1a655ad39f7");
 		}
 
 		/*******************************************************************************

--- a/src/main/resources/workflows/0.2.0/irida_workflow.xml
+++ b/src/main/resources/workflows/0.2.0/irida_workflow.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iridaWorkflow>
+  <id>d9820957-5ffc-4a25-b98b-c1a655ad39f7</id>
+  <name>micall-lite</name>
+  <version>0.2.0</version>
+  <analysisType>MICALL_LITE</analysisType>
+  <inputs>
+    <sequenceReadsPaired>sequence_reads_paired</sequenceReadsPaired>
+    <requiresSingleSample>true</requiresSingleSample>
+  </inputs>
+  <parameters>
+    <parameter name="micall_lite-1-readlen" defaultValue="251">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/public-health-bioinformatics/micall_lite/micall_lite/0.1rc3+galaxy0" parameterName="readlen"/>
+    </parameter>
+  </parameters>
+  <outputs>
+    <output name="conseq" fileName="conseq.csv"/>
+    <output name="nuc" fileName="nuc.csv"/>
+    <output name="amino" fileName="amino.csv"/>
+    <output name="insert" fileName="insert.csv"/>
+    <output name="align" fileName="align.csv"/>
+  </outputs>
+  <toolRepositories>
+    <repository>
+      <name>suite_micall_lite</name>
+      <owner>public-health-bioinformatics</owner>
+      <url>https://toolshed.g2.bx.psu.edu</url>
+      <revision>0470b6670fbc</revision>
+    </repository>
+  </toolRepositories>
+</iridaWorkflow>

--- a/src/main/resources/workflows/0.2.0/irida_workflow.xml
+++ b/src/main/resources/workflows/0.2.0/irida_workflow.xml
@@ -25,7 +25,7 @@
       <name>suite_micall_lite</name>
       <owner>public-health-bioinformatics</owner>
       <url>https://toolshed.g2.bx.psu.edu</url>
-      <revision>0470b6670fbc</revision>
+      <revision>e9618b79c799</revision>
     </repository>
   </toolRepositories>
 </iridaWorkflow>

--- a/src/main/resources/workflows/0.2.0/irida_workflow_structure.ga
+++ b/src/main/resources/workflows/0.2.0/irida_workflow_structure.ga
@@ -17,7 +17,7 @@
                 }
             ],
             "input_connections": {},
-            "tool_state": "{\"collection_type\": \"list:paired\"}",
+            "tool_state": "{\"collection_type\": \"list:paired\", \"name\": \"sequence_reads_paired\"}",
             "id": 0,
             "uuid": "f6b1e09a-6758-4e74-9f8f-4b62d81a21c7",
             "errors": null,

--- a/src/main/resources/workflows/0.2.0/irida_workflow_structure.ga
+++ b/src/main/resources/workflows/0.2.0/irida_workflow_structure.ga
@@ -1,5 +1,5 @@
 {
-    "uuid": "2ef223f7-534b-4574-b149-d02e6cf5f26b",
+    "uuid": "1552e489-4b45-4dc9-932f-cb31a40befa2",
     "tags": [],
     "format-version": "0.1",
     "name": "micall-lite",
@@ -12,29 +12,29 @@
             "workflow_outputs": [
                 {
                     "output_name": "output",
-                    "uuid": "4d9e1073-60eb-4baf-86fa-167fb355a1b8",
+                    "uuid": "8ccb8c72-86d4-4c1b-b7ee-3b69cb25640e",
                     "label": null
                 }
             ],
             "input_connections": {},
-            "tool_state": "{\"collection_type\": \"list:paired\", \"name\": \"sequence_reads_paired\"}",
+            "tool_state": "{\"collection_type\": \"list:paired\"}",
             "id": 0,
-            "uuid": "64a43b8f-e0e9-4b4c-ad8f-660688f651b1",
+            "uuid": "f6b1e09a-6758-4e74-9f8f-4b62d81a21c7",
             "errors": null,
             "name": "Input dataset collection",
-            "label": "sequence_reads_paired",
+            "label": null,
             "inputs": [],
             "position": {
-                "top": 206.5,
-                "left": 249
+                "top": 323.5,
+                "left": 233
             },
             "annotation": "",
             "content_id": null,
             "type": "data_collection_input"
         },
         "1": {
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/public-health-bioinformatics/micall_lite/micall_lite/0.1rc2+galaxy0",
-            "tool_version": "0.1rc2+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/public-health-bioinformatics/micall_lite/micall_lite/0.1rc3+galaxy0",
+            "tool_version": "0.1rc3+galaxy0",
             "outputs": [
                 {
                     "type": "csv",
@@ -60,27 +60,27 @@
             "workflow_outputs": [
                 {
                     "output_name": "insert",
-                    "uuid": "56163932-d3d6-4cf0-a13a-ad3ac31dc882",
+                    "uuid": "180f33c7-e90d-457f-bc38-b4ce5cf62bcf",
                     "label": null
                 },
                 {
                     "output_name": "align",
-                    "uuid": "8093eb30-7928-4b07-a3fd-a1d591893f17",
+                    "uuid": "ccf56d54-2265-47fc-b05f-2a418944cc2f",
                     "label": null
                 },
                 {
                     "output_name": "amino",
-                    "uuid": "22ad7caa-f3bd-43b2-b1c4-439b273ed719",
+                    "uuid": "8edeee38-7a59-474a-87fa-9b60cdfe59c2",
                     "label": null
                 },
                 {
                     "output_name": "nuc",
-                    "uuid": "2bc03d3c-6c36-4d2c-8800-934faa1a6378",
+                    "uuid": "9f103353-6fa0-4a96-b62c-f8ce3ae4e8eb",
                     "label": null
                 },
                 {
                     "output_name": "conseq",
-                    "uuid": "b1d99f5c-224a-48b7-9293-6ee400dd1219",
+                    "uuid": "23ec987d-bbee-4e73-9a36-23bfd2a4cd28",
                     "label": null
                 }
             ],
@@ -94,11 +94,11 @@
             "id": 1,
             "tool_shed_repository": {
                 "owner": "public-health-bioinformatics",
-                "changeset_revision": "023064145bea",
+                "changeset_revision": "e5390c4b69e9",
                 "name": "micall_lite",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "uuid": "c72f6ba4-d77a-455a-b805-25ef0faaa2c4",
+            "uuid": "59e6e04d-12e4-4055-854c-69a11d61e020",
             "errors": null,
             "name": "micall_lite",
             "post_job_actions": {
@@ -146,11 +146,11 @@
                 }
             ],
             "position": {
-                "top": 205.5,
-                "left": 569.5
+                "top": 350.5,
+                "left": 562.5
             },
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/public-health-bioinformatics/micall_lite/micall_lite/0.1rc2+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/public-health-bioinformatics/micall_lite/micall_lite/0.1rc3+galaxy0",
             "type": "tool"
         }
     },

--- a/src/main/resources/workflows/0.2.0/irida_workflow_structure.ga
+++ b/src/main/resources/workflows/0.2.0/irida_workflow_structure.ga
@@ -1,0 +1,159 @@
+{
+    "uuid": "2ef223f7-534b-4574-b149-d02e6cf5f26b",
+    "tags": [],
+    "format-version": "0.1",
+    "name": "micall-lite",
+    "version": 1,
+    "steps": {
+        "0": {
+            "tool_id": null,
+            "tool_version": null,
+            "outputs": [],
+            "workflow_outputs": [
+                {
+                    "output_name": "output",
+                    "uuid": "4d9e1073-60eb-4baf-86fa-167fb355a1b8",
+                    "label": null
+                }
+            ],
+            "input_connections": {},
+            "tool_state": "{\"collection_type\": \"list:paired\", \"name\": \"sequence_reads_paired\"}",
+            "id": 0,
+            "uuid": "64a43b8f-e0e9-4b4c-ad8f-660688f651b1",
+            "errors": null,
+            "name": "Input dataset collection",
+            "label": "sequence_reads_paired",
+            "inputs": [],
+            "position": {
+                "top": 206.5,
+                "left": 249
+            },
+            "annotation": "",
+            "content_id": null,
+            "type": "data_collection_input"
+        },
+        "1": {
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/public-health-bioinformatics/micall_lite/micall_lite/0.1rc2+galaxy0",
+            "tool_version": "0.1rc2+galaxy0",
+            "outputs": [
+                {
+                    "type": "csv",
+                    "name": "align"
+                },
+                {
+                    "type": "csv",
+                    "name": "amino"
+                },
+                {
+                    "type": "csv",
+                    "name": "conseq"
+                },
+                {
+                    "type": "csv",
+                    "name": "insert"
+                },
+                {
+                    "type": "csv",
+                    "name": "nuc"
+                }
+            ],
+            "workflow_outputs": [
+                {
+                    "output_name": "insert",
+                    "uuid": "56163932-d3d6-4cf0-a13a-ad3ac31dc882",
+                    "label": null
+                },
+                {
+                    "output_name": "align",
+                    "uuid": "8093eb30-7928-4b07-a3fd-a1d591893f17",
+                    "label": null
+                },
+                {
+                    "output_name": "amino",
+                    "uuid": "22ad7caa-f3bd-43b2-b1c4-439b273ed719",
+                    "label": null
+                },
+                {
+                    "output_name": "nuc",
+                    "uuid": "2bc03d3c-6c36-4d2c-8800-934faa1a6378",
+                    "label": null
+                },
+                {
+                    "output_name": "conseq",
+                    "uuid": "b1d99f5c-224a-48b7-9293-6ee400dd1219",
+                    "label": null
+                }
+            ],
+            "input_connections": {
+                "fastq_input|pair": {
+                    "output_name": "output",
+                    "id": 0
+                }
+            },
+            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"fastq_input\": \"{\\\"__current_case__\\\": 1, \\\"fastq_input_selector\\\": \\\"paired_collection\\\", \\\"pair\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}}\", \"readlen\": \"\\\"251\\\"\"}",
+            "id": 1,
+            "tool_shed_repository": {
+                "owner": "public-health-bioinformatics",
+                "changeset_revision": "023064145bea",
+                "name": "micall_lite",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "uuid": "c72f6ba4-d77a-455a-b805-25ef0faaa2c4",
+            "errors": null,
+            "name": "micall_lite",
+            "post_job_actions": {
+                "RenameDatasetActionnuc": {
+                    "output_name": "nuc",
+                    "action_type": "RenameDatasetAction",
+                    "action_arguments": {
+                        "newname": "nuc.csv"
+                    }
+                },
+                "RenameDatasetActionconseq": {
+                    "output_name": "conseq",
+                    "action_type": "RenameDatasetAction",
+                    "action_arguments": {
+                        "newname": "conseq.csv"
+                    }
+                },
+                "RenameDatasetActionamino": {
+                    "output_name": "amino",
+                    "action_type": "RenameDatasetAction",
+                    "action_arguments": {
+                        "newname": "amino.csv"
+                    }
+                },
+                "RenameDatasetActioninsert": {
+                    "output_name": "insert",
+                    "action_type": "RenameDatasetAction",
+                    "action_arguments": {
+                        "newname": "insert.csv"
+                    }
+                },
+                "RenameDatasetActionalign": {
+                    "output_name": "align",
+                    "action_type": "RenameDatasetAction",
+                    "action_arguments": {
+                        "newname": "align.csv"
+                    }
+                }
+            },
+            "label": null,
+            "inputs": [
+                {
+                    "name": "fastq_input",
+                    "description": "runtime parameter for tool micall_lite"
+                }
+            ],
+            "position": {
+                "top": 205.5,
+                "left": 569.5
+            },
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/public-health-bioinformatics/micall_lite/micall_lite/0.1rc2+galaxy0",
+            "type": "tool"
+        }
+    },
+    "annotation": "",
+    "a_galaxy_workflow": "true"
+}

--- a/src/main/resources/workflows/0.2.0/messages_en.properties
+++ b/src/main/resources/workflows/0.2.0/messages_en.properties
@@ -1,0 +1,12 @@
+#Pipeline Info Properties
+#Fri Sep 20 17:47:07 PDT 2019
+workflow.MICALL_LITE.title=MiCall-Lite Pipeline
+workflow.MICALL_LITE.description=Analyze HIV or HCV viral samples against reference genomes. Derived from the 'MiCall' pipeline from the BC Centre for Excellence in HIV/AIDS Research
+workflow.label.share-analysis-samples.MICALL_LITE=Save Results to Project Line List Metadata
+pipeline.parameters.modal-title.micall-lite=MiCall-Lite Pipeline Parameters
+pipeline.h1.micall-lite=MiCall Lite Pipeline
+pipeline.title.micall-lite=Pipelines - MiCall Lite
+#Tool Parameters - Tool: micall_lite - Workflow Step #: 1
+#Fri Sep 20 17:47:07 PDT 2019
+pipeline.parameters.micall-lite.micall_lite-1-readlen=Read Length
+


### PR DESCRIPTION
The latest rc of micall-lite fixes a couple of bugs that were preventing micall-lite from running without a couple of small patches. The new version should install and run without modification.